### PR TITLE
Remove references pj_error_log

### DIFF
--- a/templates-admin/network-admin-setup.php
+++ b/templates-admin/network-admin-setup.php
@@ -6,9 +6,7 @@ $source_id = isset( $_REQUEST['source'] ) ? intval( $_REQUEST['source'] ) : 0;
 
 // Determine/set the action to perform
 $action = ( isset( $_REQUEST['action'] ) ) ? esc_attr( $_REQUEST['action'] ) : 'list';
-pj_error_log('$action',$action);
-pj_error_log('$portal_id',$portal_id);
-pj_error_log('$source_id',$source_id);
+
 switch ( $action ) {
 
 	case "add":


### PR DESCRIPTION
Remove references pj_error_log as this function is not present in standard WordPress install.

fix https://github.com/TimeIncUK/keystone/issues/398

@philipjohn 